### PR TITLE
Add "netctl" to the list of pacstrapped packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ wifi network.
     mount /dev/sda1 /mnt/boot
 
     # Pacstrap the /mnt directory with utilities needed for arch-chroot
-    pacstrap /mnt base base-devel dialog openssl-1.0 bash-completion git intel-ucode wpa_supplicant
+    pacstrap /mnt base base-devel dialog netctl openssl-1.0 bash-completion git intel-ucode wpa_supplicant
 
     # Generate your fstab
     genfstab -pU /mnt >> /mnt/etc/fstab


### PR DESCRIPTION
Seems like "wifi-menu" is part of "netctl" now, and not in the "dialog" package.